### PR TITLE
Persist unsaved note drafts

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,7 +9,8 @@
     "permissions" : [
         "downloads", 
         "<all_urls>",
-        "tabs"
+        "tabs",
+        "storage"
     ], 
 
     "browser_action" : {

--- a/extension/popup/memory_cache.js
+++ b/extension/popup/memory_cache.js
@@ -38,10 +38,22 @@ function saveTextNote() {
         url: download, 
         filename: downloadProperties.toFileName
     });
-    
-    downloading.then(function(result) {console.log(result)});
 
+    browser.storage.local.set({note: ""});
+    document.querySelector("#text-note").value = "";
+    downloading.then(function(result) {console.log(result)});
 };
+
+function storeUnfinishedNote() {
+    var text = document.querySelector("#text-note").value;
+    browser.storage.local.set({note: text});
+}
 
 document.querySelector("#save-button").addEventListener("click", savePageAsPDF);
 document.querySelector("#save-note").addEventListener("click", saveTextNote);
+document.querySelector("#text-note").addEventListener("input", storeUnfinishedNote);
+
+var noteText = browser.storage.local.get("note");
+noteText.then((res) => {
+    if (res.note) document.querySelector("#text-note").value = res.note;
+});

--- a/extension/popup/memory_cache.js
+++ b/extension/popup/memory_cache.js
@@ -49,9 +49,19 @@ function storeUnfinishedNote() {
     browser.storage.local.set({note: text});
 }
 
+function debounce(func, delay) {
+    let debounceTimer;
+    return function() {
+        const context = this;
+        const args = arguments;
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => func.apply(context, args), delay);
+    };
+}
+
 document.querySelector("#save-button").addEventListener("click", savePageAsPDF);
 document.querySelector("#save-note").addEventListener("click", saveTextNote);
-document.querySelector("#text-note").addEventListener("input", storeUnfinishedNote);
+document.querySelector("#text-note").addEventListener("input", debounce(storeUnfinishedNote, 250));
 
 var noteText = browser.storage.local.get("note");
 noteText.then((res) => {


### PR DESCRIPTION
Persist unsaved note drafts to local storage using the [WebExtensions storage API](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage).

Resolves https://github.com/misslivirose/Memory-Cache/issues/12