### PR TITLE
Ignore .part and 0-byte files in auto ingest

### DIFF
--- a/scripts/run_ingest.sh
+++ b/scripts/run_ingest.sh
@@ -1,7 +1,11 @@
 #! /bin/bash
 
 DIR="$HOME/Downloads/MemoryCache"
-inotifywait -m -e create -e attrib "$DIR" | while read path action file; do  
-    echo "The file '$file' appeared in directory '$path'"
-    python3 ingest.py
+inotifywait -m -e close_write -e moved_to "$DIR" | while read path action file; do
+    fullPath="$path$file"
+    fileSize=$(stat -c%s "$fullPath")
+    if [[ "$file" != *.part ]] && [[ $fileSize -gt 0 ]]; then
+        echo "Ingest triggered by '$file' ($fileSize bytes)."
+        python3 ingest.py
+    fi
 done


### PR DESCRIPTION
Configure the auto ingestion script to ignore the `.part` and 0-byte files that appear while a file is downloading.

Resolves https://github.com/misslivirose/Memory-Cache/issues/11