### PR TITLE
Add button to save HTML to Memory Cache

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -1,0 +1,12 @@
+function getPageText() {
+  const head = document.head.innerHTML;
+  const body = document.body.innerText;
+  return `<!DOCTYPE html>\n<head>\n${head}\n</head>\n<body>\n${body}\n</body>\n</html>`;
+}
+
+browser.runtime.onMessage.addListener((message, _sender) => {
+  console.log("[MemoryCache Extension] Received message:", message);
+  if (message.action === "getPageText") {
+    return Promise.resolve(getPageText());
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -11,7 +11,6 @@
         "<all_urls>",
         "tabs"
     ], 
-
     "browser_action" : {
         "browser_style" : true,
         "default_icon" : "icons/memwrite-32.png", 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -16,5 +16,11 @@
         "default_icon" : "icons/memwrite-32.png", 
         "default_title" : "Memory Cache", 
         "default_popup" : "popup/memory_cache.html"
-    }
+    },
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"],
+            "js": ["content-script.js"]
+        }
+    ]
 }

--- a/extension/popup/memory_cache.html
+++ b/extension/popup/memory_cache.html
@@ -14,7 +14,9 @@
       <a href="https://github.com/misslivirose/MemoryCacheExt"><img id="headericon" src="../icons/MC-LogoNov23.svg" /></a>
     </div>
     <div class="body-container">
-      <div id="save-pdf-button" class="button primary-btn">Save page to Memory Cache</div>
+      <div id="save-pdf-button" class="button primary-btn">Save page to Memory Cache (PDF)</div>
+      <div class="border"></div>
+      <div id="save-html-button" class="button secondary-btn">Save page to Memory Cache (HTML)</div>
       <div class="border"></div>
       <div class="text-field">
         <label for="text-note">Add quick note</label>

--- a/extension/popup/memory_cache.html
+++ b/extension/popup/memory_cache.html
@@ -14,13 +14,13 @@
       <a href="https://github.com/misslivirose/MemoryCacheExt"><img id="headericon" src="../icons/MC-LogoNov23.svg" /></a>
     </div>
     <div class="body-container">
-      <div id="save-button" class="button primary-btn"> Save page to Memory Cache</div>
+      <div id="save-pdf-button" class="button primary-btn">Save page to Memory Cache</div>
       <div class="border"></div>
       <div class="text-field">
         <label for="text-note">Add quick note</label>
         <textarea id="text-note"></textarea>
       </div>
-      <div id="save-note" class="button secondary-btn"> Add text note</div>
+      <div id="save-note-button" class="button secondary-btn"> Add text note</div>
     </div>
 
     <div class="footer">

--- a/extension/popup/memory_cache.js
+++ b/extension/popup/memory_cache.js
@@ -24,6 +24,26 @@ async function savePDF() {
   }
 }
 
+// Send a message to the content script.
+//
+// We need code to run in the content script context for anything
+// that accesses the DOM or needs to outlive the popup window.
+function send(message) {
+  return new Promise((resolve, _reject) => {
+    browser.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      resolve(browser.tabs.sendMessage(tabs[0].id, message));
+    });
+  });
+}
+
+async function saveHtml() {
+  const text = await send({ action: "getPageText" });
+  const filename = `${DOWNLOAD_SUBDIRECTORY}/PAGE${generateFileName("html")}`;
+  const file = new File([text], filename, { type: "text/plain" });
+  const url = URL.createObjectURL(file);
+  browser.downloads.download({ url, filename, saveAs: false });
+}
+
 function saveNote() {
   const text = document.querySelector("#text-note").value;
   const filename = `${DOWNLOAD_SUBDIRECTORY}/NOTE${generateFileName("txt")}`;
@@ -32,5 +52,7 @@ function saveNote() {
   browser.downloads.download({ url, filename, saveAs: false });
 }
 
+document.getElementById("save-pdf-button").addEventListener("click", savePDF);
+document.getElementById("save-html-button").addEventListener("click", saveHtml);
 document.getElementById("save-pdf-button").addEventListener("click", savePDF);
 document.getElementById("save-note-button").addEventListener("click", saveNote);


### PR DESCRIPTION
Add a secondary button to save the page as HTML to memory cache. This is mostly only useful for vanilla FF, where PDF saving is not silent. 

![image](https://github.com/misslivirose/Memory-Cache/assets/4072106/a13ff393-4f14-4933-9c8c-8846388d85e3)

This PR is built on top of https://github.com/misslivirose/Memory-Cache/pull/30