### PR TITLE
Fix the broken logo link in the header

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -4,7 +4,7 @@
     {%- assign default_paths = site.pages | map: "path" -%}
     {%- assign page_paths = site.header_pages | default: default_paths -%}
     <a class="site-title" rel="author" href="{{ "/" | relative_url }}"> 
-      <img class="site-logo" src="assets/images/MC-LogoNov23.svg"/>
+      <img class="site-logo" src="/assets/images/MC-LogoNov23.svg"/>
     </a>
 
     {%- if page_paths -%}


### PR DESCRIPTION
Replacing the relative URL with the absolute URL ensures that the logo is fetched correctly from whatever page the header appears on.

Fixes https://github.com/misslivirose/Memory-Cache/issues/23

![snip_2023_11_28_14_00_31](https://github.com/misslivirose/Memory-Cache/assets/4072106/eeeafce6-1cd5-4b2b-9f04-8e0e8af1e0d7)
