### PR TITLE
Persist unfinished text notes to local storage 

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -1,0 +1,12 @@
+function getPageText() {
+  const head = document.head.innerHTML;
+  const body = document.body.innerText;
+  return `<!DOCTYPE html>\n<head>\n${head}\n</head>\n<body>\n${body}\n</body>\n</html>`;
+}
+
+browser.runtime.onMessage.addListener((message, _sender) => {
+  console.log("[MemoryCache Extension] Received message:", message);
+  if (message.action === "getPageText") {
+    return Promise.resolve(getPageText());
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,7 +9,8 @@
     "permissions" : [
         "downloads", 
         "<all_urls>",
-        "tabs"
+        "tabs",
+        "storage"
     ], 
     "browser_action" : {
         "browser_style" : true,

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -11,11 +11,16 @@
         "<all_urls>",
         "tabs"
     ], 
-
     "browser_action" : {
         "browser_style" : true,
         "default_icon" : "icons/memwrite-32.png", 
         "default_title" : "Memory Cache", 
         "default_popup" : "popup/memory_cache.html"
-    }
+    },
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"],
+            "js": ["content-script.js"]
+        }
+    ]
 }

--- a/extension/popup/memory_cache.html
+++ b/extension/popup/memory_cache.html
@@ -14,13 +14,13 @@
       <a href="https://github.com/misslivirose/MemoryCacheExt"><img id="headericon" src="../icons/MC-LogoNov23.svg" /></a>
     </div>
     <div class="body-container">
-      <div id="save-button" class="button primary-btn"> Save page to Memory Cache</div>
+      <div id="save-html-button" class="button primary-btn"> Save page to Memory Cache</div>
       <div class="border"></div>
       <div class="text-field">
         <label for="text-note">Add quick note</label>
         <textarea id="text-note"></textarea>
       </div>
-      <div id="save-note" class="button secondary-btn"> Add text note</div>
+      <div id="save-note-button" class="button secondary-btn"> Add text note</div>
     </div>
 
     <div class="footer">

--- a/extension/popup/memory_cache.js
+++ b/extension/popup/memory_cache.js
@@ -35,7 +35,34 @@ function saveNote() {
   const file = new File([text], filename, { type: "text/plain" });
   const url = URL.createObjectURL(file);
   browser.downloads.download({ url, filename, saveAs: false });
+
+  document.querySelector("#text-note").value = "";
+  browser.storage.local.set({ noteDraft: "" });
+}
+
+function debounce(func, delay) {
+  let debounceTimer;
+  return function () {
+    const context = this;
+    const args = arguments;
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => func.apply(context, args), delay);
+  };
+}
+
+function saveNoteDraft() {
+  const noteDraft = document.querySelector("#text-note").value;
+  browser.storage.local.set({ noteDraft });
 }
 
 document.getElementById("save-html-button").addEventListener("click", saveHtml);
 document.getElementById("save-note-button").addEventListener("click", saveNote);
+document
+  .getElementById("text-note")
+  .addEventListener("input", debounce(saveNoteDraft, 250));
+
+browser.storage.local.get("noteDraft").then((res) => {
+  if (res.noteDraft) {
+    document.querySelector("#text-note").value = res.noteDraft;
+  }
+});

--- a/extension/popup/memory_cache.js
+++ b/extension/popup/memory_cache.js
@@ -1,47 +1,41 @@
-
 const DOWNLOAD_SUBDIRECTORY = "MemoryCache";
 
-let downloadProperties = {
-    toFileName: "", 
-    silentMode: true
-}
-
-function onError(error) {
-    console.log(`Error: ${error}`);
-}
-
-/* 
+/*
 Generate a file name based on date and time
 */
 function generateFileName(ext) {
-    return new Date().toISOString().concat(0,19).replaceAll(":", ".") + "." + ext;
+  return (
+    new Date().toISOString().concat(0, 19).replaceAll(":", ".") + "." + ext
+  );
 }
 
-/*
-Save the active page as a PDF to the MemoryCache subdirectory
-*/
-function savePageAsPDF() {
-    downloadProperties.toFileName = "/" + DOWNLOAD_SUBDIRECTORY + "/" + generateFileName('pdf')
-    console.log(downloadProperties);
-    let saving = browser.tabs.saveAsPDF(downloadProperties).then((status) => {
-      console.log(status);
-    }); 
-    saving.then(function(result) {console.log(result)});
-};
-
-function saveTextNote() {
-    var text = document.querySelector("#text-note").value;
-    const file = new Blob([text], {type: 'text/plain'});
-    var download = URL.createObjectURL(file);
-    downloadProperties.toFileName = DOWNLOAD_SUBDIRECTORY + "/" + "NOTE" + generateFileName('txt');
-    let downloading = browser.downloads.download({
-        url: download, 
-        filename: downloadProperties.toFileName
+// Send a message to the content script.
+//
+// We need code to run in the content script context for anything
+// that accesses the DOM or needs to outlive the popup window.
+function send(message) {
+  return new Promise((resolve, _reject) => {
+    browser.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      resolve(browser.tabs.sendMessage(tabs[0].id, message));
     });
-    
-    downloading.then(function(result) {console.log(result)});
+  });
+}
 
-};
+async function saveHtml() {
+  const text = await send({ action: "getPageText" });
+  const filename = `${DOWNLOAD_SUBDIRECTORY}/PAGE${generateFileName("html")}`;
+  const file = new File([text], filename, { type: "text/plain" });
+  const url = URL.createObjectURL(file);
+  browser.downloads.download({ url, filename, saveAs: false });
+}
 
-document.querySelector("#save-button").addEventListener("click", savePageAsPDF);
-document.querySelector("#save-note").addEventListener("click", saveTextNote);
+function saveNote() {
+  const text = document.querySelector("#text-note").value;
+  const filename = `${DOWNLOAD_SUBDIRECTORY}/NOTE${generateFileName("txt")}`;
+  const file = new File([text], filename, { type: "text/plain" });
+  const url = URL.createObjectURL(file);
+  browser.downloads.download({ url, filename, saveAs: false });
+}
+
+document.getElementById("save-html-button").addEventListener("click", saveHtml);
+document.getElementById("save-note-button").addEventListener("click", saveNote);


### PR DESCRIPTION
Persist unsaved note drafts to local storage using the [WebExtensions storage API](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage).

Resolves https://github.com/misslivirose/Memory-Cache/issues/12

This is built on top of https://github.com/misslivirose/Memory-Cache/pull/26 . If #26 is merged, then the diff is just 6a407d7d9448c4355f129dbf26c4fcdf6dc071d6 .