### PR TITLE
Fallback to non-silent PDF saving in vanilla FF

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -11,7 +11,6 @@
         "<all_urls>",
         "tabs"
     ], 
-
     "browser_action" : {
         "browser_style" : true,
         "default_icon" : "icons/memwrite-32.png", 

--- a/extension/popup/memory_cache.html
+++ b/extension/popup/memory_cache.html
@@ -14,13 +14,13 @@
       <a href="https://github.com/misslivirose/MemoryCacheExt"><img id="headericon" src="../icons/MC-LogoNov23.svg" /></a>
     </div>
     <div class="body-container">
-      <div id="save-button" class="button primary-btn"> Save page to Memory Cache</div>
+      <div id="save-pdf-button" class="button primary-btn">Save page to Memory Cache</div>
       <div class="border"></div>
       <div class="text-field">
         <label for="text-note">Add quick note</label>
         <textarea id="text-note"></textarea>
       </div>
-      <div id="save-note" class="button secondary-btn"> Add text note</div>
+      <div id="save-note-button" class="button secondary-btn"> Add text note</div>
     </div>
 
     <div class="footer">


### PR DESCRIPTION
The `silentMode` parameter passed to `saveAsPDF` requires a custom firefox build, so the extension fails in vanilla firefox. 

This PR adds a fallback (non-silent save) so that the extension works in vanilla firefox (albeit without the nice silent PDF saving).